### PR TITLE
fix race condition on Close

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 test:
-	@go run github.com/onsi/ginkgo/ginkgo -keepGoing -progress -timeout 1m -race
+	@go run github.com/onsi/ginkgo/ginkgo -keepGoing -progress -timeout 1m -race --randomizeAllSpecs --randomizeSuites

--- a/buffer_test.go
+++ b/buffer_test.go
@@ -243,6 +243,33 @@ var _ = Describe("Buffer", func() {
 			// assert
 			Expect(err).To(MatchError(buffer.ErrTimeout))
 		})
+
+		It("allow Close to be called again if it fails", func() {
+			// arrange
+			flusher.Func = func() { time.Sleep(2 * time.Second) }
+
+			sut := buffer.New(
+				buffer.WithSize(1),
+				buffer.WithFlusher(flusher),
+				buffer.WithCloseTimeout(time.Second),
+			)
+			_ = sut.Push(1)
+
+			// act
+			err := sut.Close()
+
+			// assert
+			Expect(err).To(MatchError(buffer.ErrTimeout))
+
+			// arrange
+			time.Sleep(time.Second)
+
+			// act
+			err = sut.Close()
+
+			// assert
+			Expect(err).To(BeNil())
+		})
 	})
 })
 


### PR DESCRIPTION
If the flush took long enough, the `select` in `consume` could process first the signal originated from `close(buffer.dataCh)`(inside `Close`) than it would process the signal originated from `close(buffer.closeCh)`