### PR TITLE
cleanup items slice after flush

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -64,13 +64,12 @@ func (buffer *Buffer) Close() error {
 }
 
 func (buffer *Buffer) consume() {
+	count := 0
 	items := make([]interface{}, buffer.options.Size)
+	mustFlush := false
 	ticker, stopTicker := newTicker(buffer.options.FlushInterval)
 
-	count := 0
 	isOpen := true
-	mustFlush := false
-
 	for isOpen {
 		select {
 		case item := <-buffer.dataCh:
@@ -89,7 +88,9 @@ func (buffer *Buffer) consume() {
 		if mustFlush {
 			stopTicker()
 			buffer.options.Flusher.Write(items[:count])
+
 			count = 0
+			items = make([]interface{}, buffer.options.Size)
 			mustFlush = false
 			ticker, stopTicker = newTicker(buffer.options.FlushInterval)
 		}


### PR DESCRIPTION
Cleanup the slice after flush to allow the GC to collect the items in the slice.

If we don't do this, a moment of high load could put pointers to items on the whole buffer, and the pointers on the last positions would never be cleaned up until a new moment of high load.